### PR TITLE
Ticket 7929 system test & IOC refactoring

### DIFF
--- a/aeroflexSup/aeroflex_2023A.db
+++ b/aeroflexSup/aeroflex_2023A.db
@@ -50,7 +50,7 @@ record(mbbo, "$(P)MODE:SP")
     field(SDIS, "$(P)DISABLE")
 }
 
-record(calcout, "$(P)SEND_MODE_PARAMS")
+record(calcout, "$(P)SEND_MODE_PARAMS") # Currently deprecated, as OPI no longer has set button
 {
     field(DESC, "Set modulation button")
     field(SCAN, "Passive")

--- a/aeroflexSup/aeroflex_2023A.db
+++ b/aeroflexSup/aeroflex_2023A.db
@@ -50,16 +50,6 @@ record(mbbo, "$(P)MODE:SP")
     field(SDIS, "$(P)DISABLE")
 }
 
-record(calcout, "$(P)SEND_MODE_PARAMS") # Currently deprecated, as OPI no longer has set button
-{
-    field(DESC, "Set modulation button")
-    field(SCAN, "Passive")
-	field(INPA, "$(P)MODE:SP_NO_ACTION")
-	field(INPB, "$(P)PULSE_CHECK:SP")
-	field(CALC, "(B = 0) ? ((2 * A) + 1) : (2 * A)")
-	field(OUT, "$(P)MODE:SP PP")
-}
-
 ### SIMULATION RECORDS ###
 
 record(mbbi,"$(P)SIM:MODE")

--- a/aeroflexSup/aeroflex_2030.db
+++ b/aeroflexSup/aeroflex_2030.db
@@ -38,7 +38,7 @@ record(mbbo, "$(P)MODE:SP")
     field(SDIS, "$(P)DISABLE")
 }
 
-record(calcout, "$(P)SEND_MODE_PARAMS")
+record(calcout, "$(P)SEND_MODE_PARAMS") #Currently deprecated, as OPI no longer has set button
 {
     field(DESC, "Set modulation button")
     field(SCAN, "Passive")

--- a/aeroflexSup/aeroflex_2030.db
+++ b/aeroflexSup/aeroflex_2030.db
@@ -38,16 +38,6 @@ record(mbbo, "$(P)MODE:SP")
     field(SDIS, "$(P)DISABLE")
 }
 
-record(calcout, "$(P)SEND_MODE_PARAMS") #Currently deprecated, as OPI no longer has set button
-{
-    field(DESC, "Set modulation button")
-    field(SCAN, "Passive")
-	field(INPA, "$(P)MODE:SP_NO_ACTION")
-	field(INPB, "$(P)PULSE_CHECK:SP")
-	field(CALC, "((B=1)&&(A>2))?(A-3):(A+2)")
-	field(OUT, "$(P)MODE:SP PP")
-}
-
 ### SIMULATION RECORDS ###
 
 record(mbbi,"$(P)SIM:MODE")

--- a/aeroflexSup/aeroflex_common.db
+++ b/aeroflexSup/aeroflex_common.db
@@ -96,34 +96,6 @@ record(ao, "$(P)RF_LEVEL:SP")
     field(SDIS, "$(P)DISABLE")
 }
 
-record(mbbo, "$(P)MODE:SP_NO_ACTION") # modulation PV that used to control a drop-down, that no longer exists in the OPI
-
-{
-	info(autosaveFields, "VAL")
-	field(UDFS, "NO_ALARM")
-	
-	field(ZRST, "FM,AM")
-	field(ONST, "PM,AM")
-	field(TWST, "AM")
-	field(THST, "FM")
-	field(FRST, "PM")
-}
-
-record(bo, "$(P)PULSE_CHECK:SP") # pulse check button that is currently removed from OPI
-{
-    field(DESC, "Enables pulsed modulation")
-    field(SCAN, "Passive")
-	field(UDFS, "NO_ALARM")
-	
-	info(autosaveFields, "VAL")
-    
-    field(ZNAM, "Pulse disabled")
-    field(ONAM, "Pulse enabled")
-    
-    field(SIML, "$(P)SIM")
-    field(SIOL, "$(P)SIM:PULSE_CHECK:SP")
-}
-
 record(stringin, "$(P)ERROR")
 {
     field(SCAN, "2 second")

--- a/system_tests/common_tests/aeroflex.py
+++ b/system_tests/common_tests/aeroflex.py
@@ -22,7 +22,7 @@ class AeroflexTests(object):
     def test_GIVEN_new_carrier_freq_WHEN_set_carrier_freq_THEN_new_carrier_freq_set(self):        
         self.ca.set_pv_value('CARRIER_FREQ:SP', 1100)
         
-        self.ca.assert_that_pv_is('CARRIER_FREQ', 1100)
+        self.ca.assert_that_pv_is('CARRIER_FREQ:RBV', 1100)
 
     @parameterized.expand([('Value 1', 1), ('Value 2', 2), ('Value 3', 3.33333)])
     def test_GIVEN_new_rf_lvl_WHEN_set_rf_lvl_THEN_new_rf_lvl_set(self, _, value):

--- a/system_tests/common_tests/aeroflex.py
+++ b/system_tests/common_tests/aeroflex.py
@@ -20,39 +20,15 @@ class AeroflexTests(object):
     
     @skip_if_recsim("Requires emulator.")
     def test_GIVEN_new_carrier_freq_WHEN_set_carrier_freq_THEN_new_carrier_freq_set(self):        
-
-        self.ca.set_pv_value('CARRIER_FREQ:SP_NO_ACTION', 1.2)
-        self.ca.assert_that_pv_is('CARRIER_FREQ:SP_NO_ACTION', 1.2)
-        self.ca.set_pv_value('CARRIER_FREQ_UNITS:SP', 'kHZ')
-        self.ca.assert_that_pv_is('CARRIER_FREQ_UNITS:SP', 'kHZ')
-        self.ca.set_pv_value('SEND_CAR_FREQ_PARAMS.PROC', 1)
+        self.ca.set_pv_value('CARRIER_FREQ:SP', 1100)
         
-        self.ca.assert_that_pv_is('CARRIER_FREQ', 1200)
-        
-    def test_GIVEN_carrier_freq_WHEN_set_carrier_freq_readout_units_THEN_carrier_freq_readout_changes(self): 
-        self.ca.set_pv_value('CARRIER_FREQ', 1000)
-        self.ca.assert_that_pv_is('CARRIER_FREQ', 1000)
-        
-        self.ca.set_pv_value('CAR_FREQ_READOUT_UNITS', 'kHZ')
-        self.ca.assert_that_pv_is('CAR_FREQ_READOUT_UNITS', 'kHZ')
-        self.ca.set_pv_value('CALC_RETURN_CAR_FREQ.PROC', 1)
-        
-        self.ca.assert_that_pv_is('CAR_FREQ_CONV', 1)
-
-    def test_WHEN_set_carrier_freq_readout_units_incorrectly_THEN_error_thrown(self):
-        self.assertRaises(channel_access_exceptions.InvalidEnumStringException, self.ca.set_pv_value, 'CAR_FREQ_READOUT_UNITS', 'wrong')
-
+        self.ca.assert_that_pv_is('CARRIER_FREQ', 1100)
 
     @parameterized.expand([('Value 1', 1), ('Value 2', 2), ('Value 3', 3.33333)])
     def test_GIVEN_new_rf_lvl_WHEN_set_rf_lvl_THEN_new_rf_lvl_set(self, _, value):
-        self.ca.set_pv_value('RF_LEVEL:SP_NO_ACTION', value)
-        self.ca.assert_that_pv_is('RF_LEVEL:SP_NO_ACTION', value)
-        self.ca.set_pv_value('SEND_RF_LVL_PARAMS.PROC', 1)
+        self.ca.set_pv_value('RF_LEVEL:SP', value)
 
         self.ca.assert_that_pv_is('RF_LEVEL', value)
-            
-    def test_WHEN_set_modulation_incorrectly_THEN_error_thrown(self):
-        self.assertRaises(channel_access_exceptions.InvalidEnumStringException, self.ca.set_pv_value, 'MODE:SP_NO_ACTION', 'wrong')
     
     @skip_if_recsim("Requires emulator for backdoor access.")
     def test_GIVEN_error_set_THEN_error_returned(self):

--- a/system_tests/tests/aeroflex2023A.py
+++ b/system_tests/tests/aeroflex2023A.py
@@ -33,22 +33,22 @@ class Aeroflex2023ATests(AeroflexTests, unittest.TestCase):
     @parameterized.expand([('Value 1', 'AM'), ('Value 2', 'PM,AM'), ('Value 3', 'FM,AM')])
     @skip_if_recsim("Requires emulator.")
     def test_GIVEN_new_modulation_WHEN_set_modulation_THEN_new_modulation_set(self, _, value):
-        self.ca.set_pv_value('MODE:SP_NO_ACTION', value)
-        self.ca.assert_that_pv_is('MODE:SP_NO_ACTION', value)
-        self.ca.set_pv_value('SEND_MODE_PARAMS.PROC', 1)
+        self.ca.set_pv_value('MODE:SP', value)
+        self.ca.assert_that_pv_is('MODE:SP', value)
+        #self.ca.set_pv_value('SEND_MODE_PARAMS.PROC', 1)
         
         self.ca.assert_that_pv_is('MODE', value)
         
     @parameterized.expand([('Value 1', 'FM'), ('Value 2', 'PM'), ('Value 2', 'AM')])
     @skip_if_recsim("Requires emulator.")
     def test_GIVEN_new_modulation_WHEN_set_modulation_with_pulse_THEN_new_modulation_set(self, _, value):
-        self.ca.set_pv_value('MODE:SP_NO_ACTION', value)
-        self.ca.assert_that_pv_is('MODE:SP_NO_ACTION', value)
+        self.ca.set_pv_value('MODE:SP', value)
+        self.ca.assert_that_pv_is('MODE:SP', value)
         
         self.ca.set_pv_value('PULSE_CHECK:SP', 1)
         self.ca.assert_that_pv_is('PULSE_CHECK:SP', 'Pulse enabled')
         
-        self.ca.set_pv_value('SEND_MODE_PARAMS.PROC', 1)
+        #self.ca.set_pv_value('SEND_MODE_PARAMS.PROC', 1)
         
         self.ca.assert_that_pv_is('MODE', value + ',PULSE')
     

--- a/system_tests/tests/aeroflex2023A.py
+++ b/system_tests/tests/aeroflex2023A.py
@@ -30,25 +30,22 @@ class Aeroflex2023ATests(AeroflexTests, unittest.TestCase):
     def setUp(self):
         super(Aeroflex2023ATests, self).setUp()                         
 
-    @parameterized.expand([('Value 1', 'AM'), ('Value 2', 'PM,AM'), ('Value 3', 'FM,AM')])
+    @parameterized.expand([('Value 1', 'AM'), ('Value 2', 'PM,AM'), ('Value 3', 'FM,AM,PULSE'), ('Value 4', 'FSK2L,PULSE')])
     @skip_if_recsim("Requires emulator.")
     def test_GIVEN_new_modulation_WHEN_set_modulation_THEN_new_modulation_set(self, _, value):
         self.ca.set_pv_value('MODE:SP', value)
         self.ca.assert_that_pv_is('MODE:SP', value)
-        #self.ca.set_pv_value('SEND_MODE_PARAMS.PROC', 1)
         
         self.ca.assert_that_pv_is('MODE', value)
         
-    @parameterized.expand([('Value 1', 'FM'), ('Value 2', 'PM'), ('Value 2', 'AM')])
+    @parameterized.expand([('Value 1', 'FM', ''), ('Value 2', 'PM', ''), ('Value 2', 'AM', '')])
     @skip_if_recsim("Requires emulator.")
-    def test_GIVEN_new_modulation_WHEN_set_modulation_with_pulse_THEN_new_modulation_set(self, _, value):
+    def test_GIVEN_new_modulation_WHEN_set_modulation_with_pulse_THEN_new_modulation_set(self, _, value, pulse):
+        pulse = 'PULSE'
         self.ca.set_pv_value('MODE:SP', value)
         self.ca.assert_that_pv_is('MODE:SP', value)
         
-        self.ca.set_pv_value('PULSE_CHECK:SP', 1)
-        self.ca.assert_that_pv_is('PULSE_CHECK:SP', 'Pulse enabled')
-        
-        #self.ca.set_pv_value('SEND_MODE_PARAMS.PROC', 1)
+        self.ca.set_pv_value('MODE:SP', value + ',' + pulse)
         
         self.ca.assert_that_pv_is('MODE', value + ',PULSE')
     
@@ -57,11 +54,10 @@ class Aeroflex2023ATests(AeroflexTests, unittest.TestCase):
         self.ca.set_pv_value('RESET', 1)
         self.ca.assert_that_pv_is('RESET', 1)
         
-        self.ca.assert_that_pv_is('CARRIER_FREQ', 0)
+        self.ca.assert_that_pv_is('CARRIER_FREQ:RBV', 0)
         self.ca.assert_that_pv_is('RF_LEVEL', 0)
         self.ca.assert_that_pv_is('MODE', 'AM')
         
     def test_GIVEN_rf_prec_set_THEN_rf_prec_is_correct(self):
         self.ca.assert_that_pv_is('RF_LEVEL.PREC', 6)
         self.ca.assert_that_pv_is('RF_LEVEL:SP.PREC', 6)
-        self.ca.assert_that_pv_is('RF_LEVEL:SP_NO_ACTION.PREC', 6)

--- a/system_tests/tests/aeroflex2030.py
+++ b/system_tests/tests/aeroflex2030.py
@@ -30,47 +30,32 @@ class Aeroflex2030Tests(AeroflexTests, unittest.TestCase):
     def setUp(self):
         super(Aeroflex2030Tests, self).setUp()
         
-    @parameterized.expand([('Value 1', 'AM'), ('Value 2', 'PM'), ('Value 3', 'FM')])
+    @parameterized.expand([('Value 1', 'AM', ''), ('Value 2', 'PM', 'PULSE'), ('Value 3', 'FM', '')])
     @skip_if_recsim("Requires emulator.")
-    def test_GIVEN_new_modulation_WHEN_set_modulation_THEN_new_modulation_set(self, _, value):
-        self.ca.set_pv_value('MODE:SP_NO_ACTION', value)
-        self.ca.assert_that_pv_is('MODE:SP_NO_ACTION', value)
-        self.ca.set_pv_value('SEND_MODE_PARAMS.PROC', 1)
-        
-        self.ca.assert_that_pv_is('MODE', value + '1')
+    def test_GIVEN_new_modulation_WHEN_set_modulation_THEN_new_modulation_set(self, _, value, pulse):
+        self.ca.set_pv_value('MODE:SP', value)
+        if pulse=='PULSE':
+            self.ca.set_pv_value('MODE:SP', value + ',' + pulse)
+            self.ca.assert_that_pv_is('MODE', pulse + ',' + value + '1')
+        else:
+            self.ca.assert_that_pv_is('MODE', value + '1')
 
     @parameterized.expand([('Value 1', 'FM'), ('Value 2', 'PM')])
     @skip_if_recsim("Requires emulator.")
     def test_GIVEN_new_modulation_WHEN_set_modulation_with_pulse_THEN_new_modulation_set(self, _, value):
-        self.ca.set_pv_value('MODE:SP_NO_ACTION', value)
-        self.ca.assert_that_pv_is('MODE:SP_NO_ACTION', value)
-        
-        self.ca.set_pv_value('PULSE_CHECK:SP', 1)
-        self.ca.assert_that_pv_is('PULSE_CHECK:SP', 'Pulse enabled')
-        
-        self.ca.set_pv_value('SEND_MODE_PARAMS.PROC', 1)
+        self.ca.set_pv_value('MODE:SP', value)
+        self.ca.assert_that_pv_is('MODE:SP', value)
+
+        self.ca.set_pv_value('MODE:SP', value + ',' + 'PULSE')
         
         self.ca.assert_that_pv_is('MODE', 'PULSE,' + value + '1')
-    
-    @skip_if_recsim("Requires emulator.")
-    def test_GIVEN_new_modulation_WHEN_set_modulation_with_pulse_incorrectly_THEN_pulse_ignored(self):
-        self.ca.set_pv_value('MODE:SP_NO_ACTION', 'FM,AM')
-        self.ca.assert_that_pv_is('MODE:SP_NO_ACTION', 'FM,AM')
-        
-        self.ca.set_pv_value('PULSE_CHECK:SP', 1)
-        self.ca.assert_that_pv_is('PULSE_CHECK:SP', 'Pulse enabled')
-        
-        self.ca.set_pv_value('SEND_MODE_PARAMS.PROC', 1)
-        self.ca.assert_that_pv_is('MODE', 'FM1,AM1')
         
     def test_GIVEN_old_modulation_WHEN_new_modulation_set_THEN_new_modulation_is_delayed(self):
         self.ca.set_pv_value('MODE', 'AM1')
         self.ca.assert_that_pv_is('MODE', 'AM1')
         
-        self.ca.set_pv_value('MODE:SP_NO_ACTION', 'PM')
-        self.ca.assert_that_pv_is('MODE:SP_NO_ACTION', 'PM')
-        self.ca.set_pv_value('PULSE_CHECK:SP', 0)
-        self.ca.set_pv_value('SEND_MODE_PARAMS.PROC', 1)
+        self.ca.set_pv_value('MODE:SP', 'PM')
+        self.ca.assert_that_pv_is('MODE:SP', 'PM')
         
         self.ca.assert_that_pv_is('MODE', 'AM1')
         
@@ -81,11 +66,10 @@ class Aeroflex2030Tests(AeroflexTests, unittest.TestCase):
         self.ca.set_pv_value('RESET', 1)
         self.ca.assert_that_pv_is('RESET', 1)
         
-        self.ca.assert_that_pv_is('CARRIER_FREQ', 0)
+        self.ca.assert_that_pv_is('CARRIER_FREQ:RBV', 0)
         self.ca.assert_that_pv_is('RF_LEVEL', 0)
         self.ca.assert_that_pv_is('MODE', 'AM1')
         
     def test_GIVEN_rf_prec_THEN_rf_prec_is_correct(self):
         self.ca.assert_that_pv_is('RF_LEVEL.PREC', 2)
         self.ca.assert_that_pv_is('RF_LEVEL:SP.PREC', 2)
-        self.ca.assert_that_pv_is('RF_LEVEL:SP_NO_ACTION.PREC', 2)


### PR DESCRIPTION
# Summary of Work

- Link to Ticket: https://github.com/ISISComputingGroup/IBEX/issues/7929
- .db file was refactored for aeroflex.db to remove MODE:SP and PULSE_CHECK:SP, instead having modes and pulses together passed straight to either 2030.db or 2023A.db, as it was too complicated before
- System tests were refactored to function with the currently used PVs, and remove unused PVs, that were removed through the various previous tickets of Aeroflex

# How to Test

- [ ] run_tests.bat
- [ ] Connect to Aeroflex physical device and check IOC works with these final changes to .db files